### PR TITLE
Add links to previous proceedings

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -108,9 +108,12 @@
 <h3 id="previous-pacts">Previous PACTs</h3>
 
 <ul>
-  <li><a href="https://pact2024.github.io">PACT24</a></li>
-  <li><a href="https://pact2023.github.io">PACT23</a></li>
-  <li><a href="https://pact22.cs.illinois.edu/index.html">PACT22</a></li>
+  <li><a href="https://pact2024.github.io">PACT24</a>
+(<a href="https://dl.acm.org/doi/proceedings/10.1145/3656019">proceedings</a>)</li>
+  <li><a href="https://pact2023.github.io">PACT23</a>
+(<a href="https://dl.acm.org/doi/proceedings/10.5555/3703125">proceedings</a>)</li>
+  <li><a href="https://pact22.cs.illinois.edu/index.html">PACT22</a>
+(<a href="https://dl.acm.org/doi/proceedings/10.1145/3559009">proceedings</a>)</li>
   <li><a href="http://pact21.snu.ac.kr/">PACT21</a>
 (<a href="https://ieeexplore.ieee.org/xpl/conhome/9563009/proceeding">proceedings</a>)</li>
   <li><a href="https://pact20.cc.gatech.edu/">PACT20</a>


### PR DESCRIPTION
This adds links to PACT22, 23, and 24 proceedings. I was not able to build and test.